### PR TITLE
remove codesponsor

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,4 @@ yarn test
 
 It is under [the MIT license](/LICENSE).
 
-<a target='_blank' rel='nofollow' href='https://app.codesponsor.io/link/1QQGjzDQqsP1MDC8moUwzJjD/nandomoreirame/chucknorris-jokes'>
-  <img alt='Sponsor' width='888' height='68' src='https://app.codesponsor.io/embed/1QQGjzDQqsP1MDC8moUwzJjD/nandomoreirame/chucknorris-jokes.svg' />
-</a>
+


### PR DESCRIPTION
Pull request automatically sent by knewzen <https://github.com/knewzen>. Because Code Sponsor is shutting down on December 8